### PR TITLE
fix(mcp): return METHOD_NOT_FOUND for unknown requests

### DIFF
--- a/MCP/cpp-sdk/src/shared/base_session.cpp
+++ b/MCP/cpp-sdk/src/shared/base_session.cpp
@@ -179,7 +179,16 @@ void BaseSession::HandleResponse(const JSONRPCError& error)
 void BaseSession::ProcessIncomingRequest(const JSONRPCRequest& rpcRequest, RequestContext& ctx)
 {
     if (!rpcRequest.request_) {
+        // Unknown / unsupported methods deserialize with a null typed request.
+        // Return a JSON-RPC error instead of dereferencing the null pointer.
         MCP_LOG(MCP_LOG_LEVEL_ERROR, "rpcRequest.request_ is null");
+        ctx.method = rpcRequest.method_;
+        JSONRPCError error;
+        error.id_ = rpcRequest.id_;
+        error.code_ = static_cast<int>(JsonRpcErrorCode::METHOD_NOT_FOUND);
+        error.message_ = "Method not found: " + rpcRequest.method_;
+        SendResponse(rpcRequest.id_, error, ctx);
+        return;
     }
     const Request& typedRequest = *static_cast<const Request*>(rpcRequest.request_.get());
     ctx.method = typedRequest.method_;

--- a/MCP/cpp-sdk/tests/ut/shared/base_session_test.cpp
+++ b/MCP/cpp-sdk/tests/ut/shared/base_session_test.cpp
@@ -61,9 +61,9 @@ public:
 
     void SendMessage(const JSONRPCMessage& message, RequestContext& ctx) override
     {
-        (void)message;
         (void)ctx;
         sentCount_++;
+        lastMessage_ = message;
     }
 
     void HandleRequest(const Http::HttpRequest& request, RequestContext& ctx) override
@@ -74,6 +74,8 @@ public:
 
     int SentCount() const { return sentCount_; }
 
+    const std::optional<JSONRPCMessage>& LastMessage() const { return lastMessage_; }
+
     void EmitIncoming(JSONRPCMessage message, RequestContext& ctx)
     {
         if (cb_) cb_->OnMessageReceived(message, ctx);
@@ -82,6 +84,7 @@ public:
 private:
     std::shared_ptr<TransportCallback> cb_;
     int sentCount_{0};
+    std::optional<JSONRPCMessage> lastMessage_;
 };
 
 // ---------- Concrete test session ----------
@@ -335,6 +338,31 @@ TEST(BaseSessionTest, ProcessIncomingNotification_Null_NoCrash)
     ctx.sessionId = "ut";
 
     EXPECT_NO_THROW(s.OnTransportMessage(MakeNullNotificationMsg(), ctx));
+}
+
+TEST(BaseSessionTest, ProcessIncomingRequest_NullTypedRequest_SendsMethodNotFound)
+{
+    auto t = std::make_shared<FakeServerTransport>();
+    TestServerSession s(t);
+
+    JSONRPCRequest r;
+    r.jsonrpc_ = JSONRPC_VERSION;
+    r.id_ = RequestId(99);
+    r.method_ = "unknown/method";
+    r.request_.reset();
+
+    RequestContext ctx;
+    ctx.sessionId = "ut";
+
+    EXPECT_NO_THROW(s.OnTransportMessage(JSONRPCMessage{std::move(r)}, ctx));
+    EXPECT_EQ(t->SentCount(), 1);
+    ASSERT_TRUE(t->LastMessage().has_value());
+    ASSERT_TRUE(std::holds_alternative<JSONRPCError>(*t->LastMessage()));
+    const auto& err = std::get<JSONRPCError>(*t->LastMessage());
+    EXPECT_EQ(err.id_, RequestId(99));
+    EXPECT_EQ(err.code_, static_cast<int>(JsonRpcErrorCode::METHOD_NOT_FOUND));
+    EXPECT_NE(err.message_.find("unknown/method"), std::string::npos);
+    EXPECT_EQ(ctx.method, "unknown/method");
 }
 
 TEST(BaseSessionTest, SendProgressNotification_NoCrash)


### PR DESCRIPTION
Paired: [GitHub #85](https://github.com/openJiuwen-ai/agent-protocol/pull/85) ↔ [GitCode !306](https://gitcode.com/openJiuwen/agent-protocol/merge_requests/306)

﻿## Summary
- Guard `BaseSession::ProcessIncomingRequest` when `request_` is null after deserialize (unknown MCP methods).
- Reply with JSON-RPC `METHOD_NOT_FOUND` and return instead of dereferencing null (segfault).
- Add unit coverage for the null typed-request path.

Fixes #1

## Notes
- `ping` already deserializes and is handled; this closes the remaining crash for unknown methods.
- Issue #2 (empty capabilities / Accept case) looks already addressed on current `main` (serializer + `SetServerCapabilities`; HTTP header names lowercased). Left a comment on that issue.

## Test plan
- [x] Unit test `ProcessIncomingRequest_NullTypedRequest_SendsMethodNotFound`
- [ ] Build/run MCP C++ UT suite if CI provides it

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #1
- Fixes #2
<!-- /bot1-related-issues -->
