### PR TITLE
fix(mcp): advertise tools capabilities by default

### DIFF
--- a/MCP/cpp-sdk/include/mcp/mcp_type.h
+++ b/MCP/cpp-sdk/include/mcp/mcp_type.h
@@ -110,7 +110,13 @@ struct ServerConfig {
     uint32_t workerThreads{1};
     std::size_t toolsPageSize{DEFAULT_TOOLS_PAGE_SIZE};
     std::size_t resourcesPageSize{DEFAULT_RESOURCES_PAGE_SIZE};
-    ServerCapabilities capabilities{};
+    // Advertise tools by default so MCP Inspector / clients enable the Tools tab.
+    // Prompts/resources are set when registered (see McpServerImplement::Add*).
+    ServerCapabilities capabilities{[] {
+        ServerCapabilities caps;
+        caps.tools = ToolsCapabilities{};
+        return caps;
+    }()};
 };
 
 struct MCPBaseType {

--- a/MCP/cpp-sdk/src/server/mcp_server_implement.cpp
+++ b/MCP/cpp-sdk/src/server/mcp_server_implement.cpp
@@ -491,6 +491,9 @@ void McpServerImplement::AddTool(const std::string& name, ToolFunc fn, AddToolOp
     ServerTool tool(name, fn, params.title, params.description, params.inputSchema, params.outputSchema,
                     params.structuredOutput, params.annotations, params.icons);
     toolManager_.AddTool(tool);
+    if (!config_.capabilities.tools.has_value()) {
+        config_.capabilities.tools = ToolsCapabilities{};
+    }
 }
 
 void McpServerImplement::RemoveTool(const std::string& name)
@@ -520,6 +523,9 @@ void McpServerImplement::AddPrompt(const std::string& name, RenderPromptFunc han
     }
 
     promptManager_.AddPrompt(prompt, handler);
+    if (!config_.capabilities.prompts.has_value()) {
+        config_.capabilities.prompts = PromptsCapabilities{};
+    }
 }
 
 void McpServerImplement::RemovePrompt(const std::string& name)
@@ -557,6 +563,9 @@ void McpServerImplement::AddResource(const std::string& uri, const std::string& 
     }
 
     resourceManager_.AddResource(resource, readFunc);
+    if (!config_.capabilities.resources.has_value()) {
+        config_.capabilities.resources = ResourcesCapabilities{};
+    }
 }
 
 void McpServerImplement::RemoveResource(const std::string& uri)


### PR DESCRIPTION
Paired: [GitHub #90](https://github.com/openJiuwen-ai/agent-protocol/pull/90) ↔ [GitCode !307](https://gitcode.com/openJiuwen/agent-protocol/merge_requests/307)

## Summary
- Advertise `tools: {}` by default in `ServerConfig.capabilities` so MCP Inspector enables the Tools tab.
- When prompts/resources/tools are registered via `Add*`, ensure the matching capability flag is set on the server config before `Run()` copies it into sessions.

Fixes #2

## Test plan
- [ ] Initialize response includes `"capabilities": {"tools": {}}` with default config
- [ ] After `AddPrompt` / `AddResource` before `Run()`, initialize advertises those capabilities too
- [ ] Existing jsonrpc capability unit tests still pass

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #2
<!-- /bot1-related-issues -->
